### PR TITLE
Translate Java implementation to Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,217 @@
+# SemanticDecomposition
+
+Automatic construction of **semantic concept graphs** from natural language words,
+available in both **Java** (original) and **Python** (`python-rebuild` branch).
+
+Given a word, the framework queries a set of dictionary backends (WordNet,
+Wiktionary, Wikidata, …) to collect synonyms, antonyms, hypernyms, hyponyms,
+meronyms, and textual definitions, then assembles them into a weighted graph
+that downstream reasoning algorithms (marker passing, similarity measures) can
+operate on.
+
+```
+@InProceedings{Faehndrich2018,
+  author    = {Fähndrich, Johannes and Weber, Sabine and Kanthak, Hannes},
+  title     = {A Marker Passing Approach to Winograd Schemas},
+  booktitle = {Semantic Technology},
+  year      = {2018},
+  publisher = {Springer International Publishing},
+  pages     = {165--181},
+  doi       = {10.1007/978-3-030-04284-4_11}
+}
+```
+
+---
+
+## Python package (`python-rebuild` branch)
+
+### Requirements
+
+- Python 3.9+
+- `spacy` *(optional)* — lemmatisation in `BaseDictionary`; install the model
+  matching your language (`en_core_web_sm` / `de_core_news_sm`)
+
+```bash
+pip install spacy
+python -m spacy download en_core_web_sm
+```
+
+### Installation
+
+```bash
+git clone https://github.com/Datenverlust/SemanticDecomposition.git
+cd SemanticDecomposition
+git checkout python-rebuild
+
+# also needs the MarkerPassing package on PYTHONPATH:
+export PYTHONPATH="/path/to/MarkerPassingAlgorithm:$PYTHONPATH"
+
+# or install both as editable packages:
+pip install -e ../MarkerPassingAlgorithm
+pip install -e .
+```
+
+### Package structure
+
+```
+semantic_decomposition/
+├── __init__.py                     # Top-level exports
+├── i_concept.py                    # IConcept          — marker interface
+├── concept.py                      # Concept           — core semantic entity
+├── definition.py                   # Definition        — list of concepts (one per token)
+├── word_type.py                    # WordType          — Penn Treebank POS enum
+├── decomposition.py                # Decomposition     — main entry point
+├── decomposition_config.py         # DecompositionConfig
+│
+├── exceptions/
+│   └── dictionary_does_not_contain_concept_exception.py
+│
+├── settings/
+│   └── config.py                   # Config            — singleton, reads ~/.decomposition/
+│
+├── persistence/
+│   └── concept_cache.py            # ConceptCache      — singleton, pickle-backed LRU
+│
+├── dictionaries/
+│   ├── dictionary.py               # Dictionary        — ABC for all backends
+│   └── base_dictionary.py          # BaseDictionary    — NLP pipeline (spaCy)
+│
+├── entities/
+│   ├── entity.py / prime.py
+│   ├── markers/                    # DoubleMarker, DoubleMarkerWithOrigin, TypedMarker
+│   ├── links/                      # WeightedLink + Synonym/Antonym/Hypernym/…Link
+│   ├── nodes/                      # DoubleNode, DoubleNodeWithMultipleThresholds, TypedNode
+│   ├── relations/                  # Relation, Role, Synonym
+│   └── spreading_activation/       # MarkerPassingConfig, TypedMarkerPassingConfig
+│
+├── graph/
+│   ├── semantic_net.py             # SemanticNet       — replaces JGraphT
+│   ├── graph_util.py               # GraphUtil         — build/cache/merge graphs
+│   └── edges/                      # EdgeType enum, WeightedEdge
+│   └── spreading_activation/
+│       ├── count_termination_condition.py
+│       ├── double_spreading_activation.py
+│       └── marker_passing/
+│           ├── double_marker_passing.py
+│           ├── typed_marker_passing.py
+│           └── marker_passing_semantic_distance_measure.py
+│
+├── distance/
+│   ├── data_example.py
+│   ├── similarity_pair.py
+│   └── semantic_distance_measure.py  # SemanticDistanceMeasureInterface ABC
+│
+└── marker_passing/                 # Self-contained copy of the SpreadingAlgorithm base
+```
+
+### Quick start
+
+```python
+from semantic_decomposition import Concept, Definition, WordType, Decomposition
+from semantic_decomposition.dictionaries.base_dictionary import BaseDictionary
+
+# 1. Implement a Dictionary backend (e.g. wrapping NLTK WordNet)
+class MyDictionary(BaseDictionary):
+    def get_synonyms(self, word):   return []
+    def get_antonyms(self, word):   return []
+    def get_hypernyms(self, word):  return []
+    def get_hyponyms(self, word):   return []
+    def get_meronyms(self, word):   return []
+    def get_definitions(self, word):return []
+    def fill_concept(self, concept):return concept
+    def get_lemma(self, word):      return word
+    def get_concept(self, word):
+        c = Concept()
+        c.litheral = word
+        return c
+    def set_pos(self, concept):     return concept
+    def fill_definition(self, d):   return d
+    def fill_related(self, c):      return c
+
+# 2. Initialise Decomposition with your backend(s)
+Decomposition.init([MyDictionary()])
+
+# 3. Decompose a word into a Concept
+cat = Decomposition.create_concept("cat", WordType.NN)
+cat = Decomposition.decompose(cat)
+
+# 4. Measure semantic distance
+from semantic_decomposition.graph.spreading_activation.marker_passing import (
+    MarkerPassingSemanticDistanceMeasure,
+)
+
+dog = Decomposition.create_concept("dog", WordType.NN)
+dog = Decomposition.decompose(dog)
+
+measure = MarkerPassingSemanticDistanceMeasure()
+similarity = measure.compare_concepts(cat, dog)
+print(f"cat ↔ dog similarity: {similarity:.4f}")
+```
+
+### Configuration
+
+Create `~/.decomposition/decomposition.cfg`:
+
+```ini
+[decomposition]
+language = EN          # EN or GER
+primes_dir = ~/.decomposition/primes
+stop_words = the, a, an, of
+```
+
+---
+
+## Java package (original)
+
+### Requirements
+
+- Java 8, Maven, ≥ 8 GB RAM (16 GB recommended for full Wikidata)
+
+### Build
+
+```bash
+# 1. Install MarkerPassingAlgorithm
+git clone https://github.com/Datenverlust/MarkerPassingAlgorithm.git
+cd MarkerPassingAlgorithm && mvn clean install && cd ..
+
+# 2. Install JWKTL
+git clone https://github.com/dkpro/dkpro-jwktl.git
+cd dkpro-jwktl && mvn clean install && cd ..
+
+# 3. Build SemanticDecomposition
+git clone https://github.com/Datenverlust/SemanticDecomposition.git
+cd SemanticDecomposition && mvn clean install
+```
+
+> **First run note:** WordNet, Wiktionary, and Wikidata are downloaded and
+> converted into local databases on first use. This can take a long time and
+> significant disk space (Wikidata extracted: ~250 GB).
+
+---
+
+## Key translation decisions (Java → Python)
+
+| Java | Python |
+|---|---|
+| JGraphT `Graph` | Custom `SemanticNet` (dict-backed adjacency) |
+| Guava `LoadingCache` | `dict`-based `ConceptCache` (pickle persistence) |
+| Guava `BiMap` | Two mirrored `dict`s |
+| `StanfordCoreNLP` | Optional `spaCy` pipeline |
+| `ExecutorService` | `concurrent.futures.ThreadPoolExecutor` |
+| Java `enum` | `enum.Enum` |
+| Singleton `getInstance()` | Class-level `_instance` pattern |
+
+---
+
+## Related projects
+
+- **MarkerPassingAlgorithm** — spreading-activation engine used internally
+- **SemanticDecompositionExperiments** — NLP experiments built on top of this library
+
+---
+
+## License
+
+[GPLv3](https://www.gnu.org/licenses/gpl-3.0.html)
+
+Contact: datenverlust@gmail.com

--- a/semantic_decomposition/__init__.py
+++ b/semantic_decomposition/__init__.py
@@ -1,0 +1,15 @@
+from .i_concept import IConcept
+from .concept import Concept
+from .definition import Definition
+from .word_type import WordType
+from .decomposition import Decomposition
+from .decomposition_config import DecompositionConfig
+
+__all__ = [
+    "IConcept",
+    "Concept",
+    "Definition",
+    "WordType",
+    "Decomposition",
+    "DecompositionConfig",
+]

--- a/semantic_decomposition/concept.py
+++ b/semantic_decomposition/concept.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from typing import Dict, List, Optional
+from .i_concept import IConcept
+from .word_type import WordType
+
+
+class Concept(IConcept):
+    """Core data type representing a word/concept with all its semantic relations."""
+
+    def __init__(self) -> None:
+        self.litheral: str = ""
+        self.word_type: Optional[WordType] = None
+        self.id: int = 0
+        self.synonyms: List["Concept"] = []
+        self.antonyms: List["Concept"] = []
+        self.hypernyms: List["Concept"] = []
+        self.hyponyms: List["Concept"] = []
+        self.meronyms: List["Concept"] = []
+        self.definitions: List[object] = []
+        self.derivations: List["Concept"] = []
+        self.arbitrary_relations: Dict[str, List["Concept"]] = {}
+        self.lemma: str = ""
+        self.ner: str = ""
+        self.originated_relation_name: str = ""
+
+    def __repr__(self) -> str:
+        return f"Concept({self.litheral!r})"
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Concept):
+            return NotImplemented
+        return self.id == other.id

--- a/semantic_decomposition/decomposition.py
+++ b/semantic_decomposition/decomposition.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+import concurrent.futures
+from typing import Dict, List, Optional, Set, TYPE_CHECKING
+
+from .concept import Concept
+from .definition import Definition
+from .word_type import WordType
+from .decomposition_config import DecompositionConfig
+from .persistence.concept_cache import ConceptCache
+
+if TYPE_CHECKING:
+    from .dictionaries.dictionary import Dictionary
+
+
+class Decomposition:
+    """
+    Main entry point for semantic decomposition.
+
+    Manages a list of Dictionary backends and a ConceptCache.
+    Provides single- and multi-threaded concept decomposition.
+    """
+
+    dictionaries: List["Dictionary"] = []
+    concept_cache: ConceptCache = ConceptCache.get_instance()
+    n_sm_primes: List[str] = []
+    concepts_to_ignore: Set[str] = set()
+
+    @classmethod
+    def init(cls, dictionaries: List["Dictionary"]) -> None:
+        cls.dictionaries = dictionaries
+        for d in dictionaries:
+            if hasattr(d, "init"):
+                d.init()
+
+    @classmethod
+    def create_concept(cls, litheral: str, word_type: Optional[WordType] = None) -> Concept:
+        concept = Concept()
+        concept.litheral = litheral
+        concept.word_type = word_type
+        return concept
+
+    @classmethod
+    def decompose(cls, concept: Concept) -> Concept:
+        cached = cls.concept_cache.get(concept.id)
+        if cached is not None:
+            return cached
+        for dictionary in cls.dictionaries:
+            try:
+                concept = dictionary.fill_concept(concept)
+            except Exception:
+                continue
+        cls.concept_cache.put(concept)
+        return concept
+
+    @classmethod
+    def multi_threaded_decompose(cls, concepts: List[Concept]) -> List[Concept]:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=DecompositionConfig.thread_count
+        ) as executor:
+            futures = {executor.submit(cls.decompose, c): c for c in concepts}
+            results = []
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    results.append(future.result())
+                except Exception:
+                    results.append(futures[future])
+        return results
+
+    @classmethod
+    def check_is_prime(cls, word: str) -> bool:
+        return word in cls.n_sm_primes
+
+    @classmethod
+    def get_prime_of_concept(cls, concept: Concept) -> Optional[str]:
+        if cls.check_is_prime(concept.litheral):
+            return concept.litheral
+        return None

--- a/semantic_decomposition/decomposition_config.py
+++ b/semantic_decomposition/decomposition_config.py
@@ -1,0 +1,5 @@
+class DecompositionConfig:
+    """Global configuration knobs for the decomposition algorithm."""
+
+    thread_count: int = 4
+    cache_size: int = 100

--- a/semantic_decomposition/definition.py
+++ b/semantic_decomposition/definition.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .concept import Concept
+
+
+class Definition:
+    """A definition expressed as a list of concepts (one per token)."""
+
+    def __init__(self, concepts: List["Concept"] | None = None) -> None:
+        self._concepts: List["Concept"] = concepts if concepts is not None else []
+
+    @property
+    def concepts(self) -> List["Concept"]:
+        return self._concepts
+
+    @concepts.setter
+    def concepts(self, value: List["Concept"]) -> None:
+        self._concepts = value
+
+    def __repr__(self) -> str:
+        return f"Definition({self._concepts!r})"

--- a/semantic_decomposition/dictionaries/__init__.py
+++ b/semantic_decomposition/dictionaries/__init__.py
@@ -1,0 +1,4 @@
+from .dictionary import Dictionary
+from .base_dictionary import BaseDictionary
+
+__all__ = ["Dictionary", "BaseDictionary"]

--- a/semantic_decomposition/dictionaries/base_dictionary.py
+++ b/semantic_decomposition/dictionaries/base_dictionary.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+from abc import abstractmethod
+from typing import List, Optional, TYPE_CHECKING
+
+from .dictionary import Dictionary
+from ..settings.config import Config, Language
+
+if TYPE_CHECKING:
+    from ..concept import Concept
+    from ..definition import Definition
+
+try:
+    import spacy
+    _SPACY_AVAILABLE = True
+except ImportError:
+    _SPACY_AVAILABLE = False
+
+
+class BaseDictionary(Dictionary):
+    """Abstract base providing shared NLP pipeline (spaCy replacing StanfordCoreNLP)."""
+
+    _nlp = None
+
+    @classmethod
+    def init(cls) -> None:
+        if not _SPACY_AVAILABLE:
+            return
+        config = Config.get_instance()
+        model = "en_core_web_sm" if config.language == Language.EN else "de_core_news_sm"
+        try:
+            cls._nlp = spacy.load(model)
+        except OSError:
+            cls._nlp = None
+
+    def set_lemma(self, concept: "Concept") -> "Concept":
+        if self._nlp is None:
+            concept.lemma = concept.litheral
+            return concept
+        doc = self._nlp(concept.litheral)
+        if doc:
+            concept.lemma = doc[0].lemma_
+        else:
+            concept.lemma = concept.litheral
+        return concept
+
+    @abstractmethod
+    def get_synonyms(self, word: str) -> List["Concept"]: ...
+
+    @abstractmethod
+    def get_antonyms(self, word: str) -> List["Concept"]: ...
+
+    @abstractmethod
+    def get_hypernyms(self, word: str) -> List["Concept"]: ...
+
+    @abstractmethod
+    def get_hyponyms(self, word: str) -> List["Concept"]: ...
+
+    @abstractmethod
+    def get_meronyms(self, word: str) -> List["Concept"]: ...
+
+    @abstractmethod
+    def get_definitions(self, word: str) -> List["Definition"]: ...
+
+    @abstractmethod
+    def fill_concept(self, concept: "Concept") -> "Concept": ...
+
+    @abstractmethod
+    def get_lemma(self, word: str) -> str: ...
+
+    @abstractmethod
+    def get_concept(self, word: str) -> "Concept": ...
+
+    @abstractmethod
+    def set_pos(self, concept: "Concept") -> "Concept": ...
+
+    @abstractmethod
+    def fill_definition(self, definition: "Definition") -> "Definition": ...
+
+    @abstractmethod
+    def fill_related(self, concept: "Concept") -> "Concept": ...

--- a/semantic_decomposition/dictionaries/dictionary.py
+++ b/semantic_decomposition/dictionaries/dictionary.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..concept import Concept
+    from ..definition import Definition
+    from ..word_type import WordType
+
+
+class Dictionary(ABC):
+    """Interface every semantic dictionary backend must implement."""
+
+    @abstractmethod
+    def get_synonyms(self, word: str) -> List["Concept"]: ...
+
+    @abstractmethod
+    def get_antonyms(self, word: str) -> List["Concept"]: ...
+
+    @abstractmethod
+    def get_hypernyms(self, word: str) -> List["Concept"]: ...
+
+    @abstractmethod
+    def get_hyponyms(self, word: str) -> List["Concept"]: ...
+
+    @abstractmethod
+    def get_meronyms(self, word: str) -> List["Concept"]: ...
+
+    @abstractmethod
+    def get_definitions(self, word: str) -> List["Definition"]: ...
+
+    @abstractmethod
+    def fill_concept(self, concept: "Concept") -> "Concept": ...
+
+    @abstractmethod
+    def get_lemma(self, word: str) -> str: ...
+
+    @abstractmethod
+    def get_concept(self, word: str) -> "Concept": ...
+
+    @abstractmethod
+    def set_pos(self, concept: "Concept") -> "Concept": ...
+
+    @abstractmethod
+    def fill_definition(self, definition: "Definition") -> "Definition": ...
+
+    @abstractmethod
+    def fill_related(self, concept: "Concept") -> "Concept": ...
+
+    @abstractmethod
+    def set_lemma(self, concept: "Concept") -> "Concept": ...

--- a/semantic_decomposition/distance/__init__.py
+++ b/semantic_decomposition/distance/__init__.py
@@ -1,0 +1,5 @@
+from .data_example import DataExample
+from .similarity_pair import SimilarityPair
+from .semantic_distance_measure import SemanticDistanceMeasureInterface
+
+__all__ = ["DataExample", "SimilarityPair", "SemanticDistanceMeasureInterface"]

--- a/semantic_decomposition/distance/data_example.py
+++ b/semantic_decomposition/distance/data_example.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+import copy
+
+
+class DataExample:
+    """Holds a measured result and an optional ground-truth value."""
+
+    def __init__(self, result: float = 0.0, true_result: float = 0.0) -> None:
+        self.result: float = result
+        self.true_result: float = true_result
+
+    def clone(self) -> "DataExample":
+        return copy.copy(self)
+
+    def __repr__(self) -> str:
+        return f"DataExample(result={self.result}, true_result={self.true_result})"

--- a/semantic_decomposition/distance/semantic_distance_measure.py
+++ b/semantic_decomposition/distance/semantic_distance_measure.py
@@ -1,0 +1,7 @@
+from abc import ABC, abstractmethod
+from ..i_concept import IConcept
+
+
+class SemanticDistanceMeasureInterface(ABC):
+    @abstractmethod
+    def compare_concepts(self, c1: IConcept, c2: IConcept) -> float: ...

--- a/semantic_decomposition/distance/similarity_pair.py
+++ b/semantic_decomposition/distance/similarity_pair.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+import copy
+from .data_example import DataExample
+
+
+class SimilarityPair(DataExample):
+    """DataExample that also carries the two strings being compared."""
+
+    def __init__(
+        self,
+        string1: str = "",
+        string2: str = "",
+        result: float = 0.0,
+        true_result: float = 0.0,
+    ) -> None:
+        super().__init__(result, true_result)
+        self.string1: str = string1
+        self.string2: str = string2
+
+    def clone(self) -> "SimilarityPair":
+        return copy.copy(self)
+
+    def __repr__(self) -> str:
+        return (
+            f"SimilarityPair({self.string1!r}, {self.string2!r}, "
+            f"result={self.result}, true_result={self.true_result})"
+        )

--- a/semantic_decomposition/entities/__init__.py
+++ b/semantic_decomposition/entities/__init__.py
@@ -1,0 +1,4 @@
+from .entity import Entity
+from .prime import Prime
+
+__all__ = ["Entity", "Prime"]

--- a/semantic_decomposition/entities/entity.py
+++ b/semantic_decomposition/entities/entity.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .relations.relation import Relation
+
+
+class Entity:
+    def __init__(self, name: str = "") -> None:
+        self.name: str = name
+        self.relations: List["Relation"] = []
+
+    def is_relationship(self) -> bool:
+        return False
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.name!r})"
+
+    def __hash__(self) -> int:
+        return hash(self.name)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Entity):
+            return NotImplemented
+        return self.name == other.name

--- a/semantic_decomposition/entities/links/__init__.py
+++ b/semantic_decomposition/entities/links/__init__.py
@@ -1,0 +1,12 @@
+from .weighted_link import WeightedLink
+from .definition_link import DefinitionLink
+from .synonym_link import SynonymLink
+from .hypernym_link import HypernymLink
+from .hyponym_link import HyponymLink
+from .antonym_link import AntonymLink
+from .arbitrary_relation_link import ArbitraryRelationLink
+
+__all__ = [
+    "WeightedLink", "DefinitionLink", "SynonymLink", "HypernymLink",
+    "HyponymLink", "AntonymLink", "ArbitraryRelationLink",
+]

--- a/semantic_decomposition/entities/links/antonym_link.py
+++ b/semantic_decomposition/entities/links/antonym_link.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+
+from .weighted_link import WeightedLink
+
+if TYPE_CHECKING:
+    from ...marker_passing.node import Node
+    from ..spreading_activation.marker_passing_config import MarkerPassingConfig
+
+
+class AntonymLink(WeightedLink):
+    def __init__(
+        self,
+        source: Optional["Node"] = None,
+        target: Optional["Node"] = None,
+        config: Optional["MarkerPassingConfig"] = None,
+    ) -> None:
+        weight = config.get_antonym_link_weight() if config else -0.9
+        super().__init__(source, target, weight, config)

--- a/semantic_decomposition/entities/links/arbitrary_relation_link.py
+++ b/semantic_decomposition/entities/links/arbitrary_relation_link.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+
+from .weighted_link import WeightedLink
+
+if TYPE_CHECKING:
+    from ...marker_passing.node import Node
+    from ..spreading_activation.marker_passing_config import MarkerPassingConfig
+
+
+class ArbitraryRelationLink(WeightedLink):
+    def __init__(
+        self,
+        source: Optional["Node"] = None,
+        target: Optional["Node"] = None,
+        config: Optional["MarkerPassingConfig"] = None,
+        relation_name: str = "",
+    ) -> None:
+        weight = config.get_arbitrary_relation_link_weight() if config else 0.0
+        super().__init__(source, target, weight, config)
+        self.relation_name: str = relation_name

--- a/semantic_decomposition/entities/links/definition_link.py
+++ b/semantic_decomposition/entities/links/definition_link.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+
+from .weighted_link import WeightedLink
+
+if TYPE_CHECKING:
+    from ...marker_passing.node import Node
+    from ..spreading_activation.marker_passing_config import MarkerPassingConfig
+
+
+class DefinitionLink(WeightedLink):
+    def __init__(
+        self,
+        source: Optional["Node"] = None,
+        target: Optional["Node"] = None,
+        config: Optional["MarkerPassingConfig"] = None,
+    ) -> None:
+        weight = config.get_definition_link_weight() if config else -0.78
+        super().__init__(source, target, weight, config)

--- a/semantic_decomposition/entities/links/hypernym_link.py
+++ b/semantic_decomposition/entities/links/hypernym_link.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+
+from .weighted_link import WeightedLink
+
+if TYPE_CHECKING:
+    from ...marker_passing.node import Node
+    from ..spreading_activation.marker_passing_config import MarkerPassingConfig
+
+
+class HypernymLink(WeightedLink):
+    def __init__(
+        self,
+        source: Optional["Node"] = None,
+        target: Optional["Node"] = None,
+        config: Optional["MarkerPassingConfig"] = None,
+    ) -> None:
+        weight = config.get_hypernym_link_weight() if config else -0.02
+        super().__init__(source, target, weight, config)

--- a/semantic_decomposition/entities/links/hyponym_link.py
+++ b/semantic_decomposition/entities/links/hyponym_link.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+
+from .weighted_link import WeightedLink
+
+if TYPE_CHECKING:
+    from ...marker_passing.node import Node
+    from ..spreading_activation.marker_passing_config import MarkerPassingConfig
+
+
+class HyponymLink(WeightedLink):
+    def __init__(
+        self,
+        source: Optional["Node"] = None,
+        target: Optional["Node"] = None,
+        config: Optional["MarkerPassingConfig"] = None,
+    ) -> None:
+        weight = config.get_hyponym_link_weight() if config else 0.79
+        super().__init__(source, target, weight, config)

--- a/semantic_decomposition/entities/links/synonym_link.py
+++ b/semantic_decomposition/entities/links/synonym_link.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+
+from .weighted_link import WeightedLink
+
+if TYPE_CHECKING:
+    from ...marker_passing.node import Node
+    from ..spreading_activation.marker_passing_config import MarkerPassingConfig
+
+
+class SynonymLink(WeightedLink):
+    def __init__(
+        self,
+        source: Optional["Node"] = None,
+        target: Optional["Node"] = None,
+        config: Optional["MarkerPassingConfig"] = None,
+    ) -> None:
+        weight = config.get_synonym_link_weight() if config else 0.62
+        super().__init__(source, target, weight, config)

--- a/semantic_decomposition/entities/links/weighted_link.py
+++ b/semantic_decomposition/entities/links/weighted_link.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+
+from ...marker_passing.link import Link
+
+if TYPE_CHECKING:
+    from ...marker_passing.node import Node
+    from ..spreading_activation.marker_passing_config import MarkerPassingConfig
+
+
+class WeightedLink(Link):
+    """Directed link between two nodes carrying a numeric weight."""
+
+    def __init__(
+        self,
+        source: Optional["Node"] = None,
+        target: Optional["Node"] = None,
+        weight: float = 0.0,
+        config: Optional["MarkerPassingConfig"] = None,
+    ) -> None:
+        self._source = source
+        self._target = target
+        self._weight = weight
+        self._config = config
+
+    @property
+    def source(self) -> Optional["Node"]:
+        return self._source
+
+    @source.setter
+    def source(self, value: "Node") -> None:
+        self._source = value
+
+    @property
+    def target(self) -> Optional["Node"]:
+        return self._target
+
+    @target.setter
+    def target(self, value: "Node") -> None:
+        self._target = value
+
+    @property
+    def weight(self) -> float:
+        return self._weight
+
+    @property
+    def marker_passing_config(self) -> Optional["MarkerPassingConfig"]:
+        return self._config
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, WeightedLink):
+            return NotImplemented
+        return self._source == other._source and self._target == other._target
+
+    def __hash__(self) -> int:
+        return hash((id(self._source), id(self._target)))

--- a/semantic_decomposition/entities/markers/__init__.py
+++ b/semantic_decomposition/entities/markers/__init__.py
@@ -1,0 +1,5 @@
+from .double_marker import DoubleMarker
+from .double_marker_with_origin import DoubleMarkerWithOrigin
+from .typed_marker import TypedMarker
+
+__all__ = ["DoubleMarker", "DoubleMarkerWithOrigin", "TypedMarker"]

--- a/semantic_decomposition/entities/markers/double_marker.py
+++ b/semantic_decomposition/entities/markers/double_marker.py
@@ -1,0 +1,11 @@
+from ...marker_passing.marker import Marker
+
+
+class DoubleMarker(Marker):
+    """Marker carrying a single floating-point activation value."""
+
+    def __init__(self, activation: float = 0.0) -> None:
+        self.activation: float = activation
+
+    def __repr__(self) -> str:
+        return f"DoubleMarker({self.activation})"

--- a/semantic_decomposition/entities/markers/double_marker_with_origin.py
+++ b/semantic_decomposition/entities/markers/double_marker_with_origin.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from typing import List, Optional, TYPE_CHECKING
+
+from ...marker_passing.marker import Marker
+
+if TYPE_CHECKING:
+    from ..links.weighted_link import WeightedLink
+    from ...concept import Concept
+
+
+class DoubleMarkerWithOrigin(Marker):
+    """Marker tracking activation, its origin concept, and the traversal path."""
+
+    def __init__(
+        self,
+        activation: float = 0.0,
+        origin: Optional["Concept"] = None,
+        link_type: str = "",
+    ) -> None:
+        self.activation: float = activation
+        self.origin: Optional["Concept"] = origin
+        self.link_type: str = link_type
+        self.visited_concepts: List["Concept"] = []
+        self.visited_links: List["WeightedLink"] = []
+        self.answers: List["Concept"] = []
+
+    def __repr__(self) -> str:
+        return f"DoubleMarkerWithOrigin(activation={self.activation}, origin={self.origin})"

--- a/semantic_decomposition/entities/markers/typed_marker.py
+++ b/semantic_decomposition/entities/markers/typed_marker.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+
+from ...marker_passing.marker import Marker
+
+if TYPE_CHECKING:
+    from ...concept import Concept
+
+
+class TypedMarker(Marker):
+    """Marker with a numeric value, an origin concept, and a type identifier."""
+
+    def __init__(
+        self,
+        value: float = 0.0,
+        origin: Optional["Concept"] = None,
+        marker_type: int = 0,
+    ) -> None:
+        self.value: float = value
+        self.origin: Optional["Concept"] = origin
+        self.type: int = marker_type
+
+    def __repr__(self) -> str:
+        return f"TypedMarker(value={self.value}, type={self.type})"

--- a/semantic_decomposition/entities/nodes/__init__.py
+++ b/semantic_decomposition/entities/nodes/__init__.py
@@ -1,0 +1,5 @@
+from .double_node import DoubleNode
+from .double_node_with_multiple_thresholds import DoubleNodeWithMultipleThresholds
+from .typed_node import TypedNode
+
+__all__ = ["DoubleNode", "DoubleNodeWithMultipleThresholds", "TypedNode"]

--- a/semantic_decomposition/entities/nodes/double_node.py
+++ b/semantic_decomposition/entities/nodes/double_node.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+from typing import Collection, List, Optional, TYPE_CHECKING
+
+from ...marker_passing.node import Node
+from ...marker_passing.spreading_step import SpreadingStep
+
+if TYPE_CHECKING:
+    from ...marker_passing.link import Link
+    from ...marker_passing.marker import Marker
+    from ..markers.double_marker import DoubleMarker
+    from ...concept import Concept
+    from ..spreading_activation.marker_passing_config import MarkerPassingConfig
+
+
+class DoubleNode(Node):
+    """Node accumulating a single double activation value for marker passing."""
+
+    def __init__(
+        self,
+        litheral: str = "",
+        concept: Optional["Concept"] = None,
+        config: Optional["MarkerPassingConfig"] = None,
+    ) -> None:
+        self.litheral: str = litheral
+        self.concept: Optional["Concept"] = concept
+        self._links: List["Link"] = []
+        self._markers: List["Marker"] = []
+        self.threshold: float = config.threshold if config else 0.064
+        self.activation: float = 0.0
+        self._config = config
+
+    def get_links(self) -> List["Link"]:
+        return self._links
+
+    def get_markers(self) -> List["Marker"]:
+        return self._markers
+
+    def check_thresholds(self, marker_classes: object = None) -> bool:
+        return self.activation >= self.threshold
+
+    def in_function(self, input_steps: Collection[SpreadingStep]) -> None:
+        from ..markers.double_marker import DoubleMarker
+        for step in input_steps:
+            for marker in step.markings:
+                if isinstance(marker, DoubleMarker):
+                    self.activation += marker.activation
+        self._markers.clear()
+        if self.activation != 0.0:
+            self._markers.append(DoubleMarker(self.activation))
+
+    def out_function(self) -> Collection[SpreadingStep]:
+        from ..markers.double_marker import DoubleMarker
+        steps: List[SpreadingStep] = []
+        for link in self._links:
+            from ..links.weighted_link import WeightedLink
+            if isinstance(link, WeightedLink):
+                activation = self.activation * link.weight
+                step = SpreadingStep()
+                step.link = link
+                step.in_direction = True
+                step.markings = [DoubleMarker(activation)]
+                steps.append(step)
+        return steps
+
+    def __repr__(self) -> str:
+        return f"DoubleNode({self.litheral!r}, activation={self.activation})"
+
+    def __hash__(self) -> int:
+        return hash(self.litheral)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, DoubleNode):
+            return NotImplemented
+        return self.litheral == other.litheral

--- a/semantic_decomposition/entities/nodes/double_node_with_multiple_thresholds.py
+++ b/semantic_decomposition/entities/nodes/double_node_with_multiple_thresholds.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+from collections import defaultdict
+from typing import Collection, Dict, List, Optional, Tuple, TYPE_CHECKING
+
+from ...marker_passing.node import Node
+from ...marker_passing.spreading_step import SpreadingStep
+
+if TYPE_CHECKING:
+    from ...marker_passing.link import Link
+    from ...marker_passing.marker import Marker
+    from ...concept import Concept
+    from ..spreading_activation.marker_passing_config import MarkerPassingConfig
+
+
+class DoubleNodeWithMultipleThresholds(Node):
+    """Node that tracks separate activation histories per originating concept."""
+
+    def __init__(
+        self,
+        litheral: str = "",
+        concept: Optional["Concept"] = None,
+        config: Optional["MarkerPassingConfig"] = None,
+    ) -> None:
+        self.litheral: str = litheral
+        self.concept: Optional["Concept"] = concept
+        self._links: List["Link"] = []
+        self._markers: List["Marker"] = []
+        self._config = config
+        # Map[origin_concept -> Map[activation -> List[arriving_concept]]]
+        self.activation: Dict["Concept", Dict[float, List["Concept"]]] = defaultdict(
+            lambda: defaultdict(list)
+        )
+        self.activation_history: Dict["Concept", List[float]] = defaultdict(list)
+        self._threshold_per_concept: Dict["Concept", float] = {}
+
+    def get_threshold_for(self, concept: "Concept") -> float:
+        from ..spreading_activation.marker_passing_config import MarkerPassingConfig
+        return self._threshold_per_concept.get(
+            concept,
+            self._config.threshold if self._config else MarkerPassingConfig.threshold,
+        )
+
+    def get_links(self) -> List["Link"]:
+        return self._links
+
+    def get_markers(self) -> List["Marker"]:
+        return self._markers
+
+    def check_thresholds(self, marker_classes: object = None) -> bool:
+        for origin, act_map in self.activation.items():
+            for act_val in act_map:
+                if act_val >= self.get_threshold_for(origin):
+                    return True
+        return False
+
+    def in_function(self, input_steps: Collection[SpreadingStep]) -> None:
+        from ..markers.double_marker_with_origin import DoubleMarkerWithOrigin
+        for step in input_steps:
+            for marker in step.markings:
+                if isinstance(marker, DoubleMarkerWithOrigin) and marker.origin is not None:
+                    self.activation[marker.origin][marker.activation].append(marker.origin)
+                    self.activation_history[marker.origin].append(marker.activation)
+
+    def out_function(self) -> Collection[SpreadingStep]:
+        from ..markers.double_marker_with_origin import DoubleMarkerWithOrigin
+        steps: List[SpreadingStep] = []
+        for link in self._links:
+            from ..links.weighted_link import WeightedLink
+            if not isinstance(link, WeightedLink):
+                continue
+            for origin, act_map in self.activation.items():
+                for act_val in act_map:
+                    new_act = act_val * link.weight
+                    marker = DoubleMarkerWithOrigin(
+                        activation=new_act, origin=origin
+                    )
+                    step = SpreadingStep()
+                    step.link = link
+                    step.in_direction = True
+                    step.markings = [marker]
+                    steps.append(step)
+        return steps
+
+    def __repr__(self) -> str:
+        return f"DoubleNodeWithMultipleThresholds({self.litheral!r})"
+
+    def __hash__(self) -> int:
+        return hash(self.litheral)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, DoubleNodeWithMultipleThresholds):
+            return NotImplemented
+        return self.litheral == other.litheral

--- a/semantic_decomposition/entities/nodes/typed_node.py
+++ b/semantic_decomposition/entities/nodes/typed_node.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+from typing import Collection, Dict, List, Optional, TYPE_CHECKING
+
+from ...marker_passing.node import Node
+from ...marker_passing.spreading_step import SpreadingStep
+
+if TYPE_CHECKING:
+    from ...marker_passing.link import Link
+    from ...marker_passing.marker import Marker
+    from ...concept import Concept
+    from ..markers.typed_marker import TypedMarker
+
+
+_C_T: float = 100_000.0
+
+
+class TypedNode(Node):
+    """Node for typed marker-passing; tracks per-(concept, type) activation."""
+
+    def __init__(
+        self,
+        litheral: str = "",
+        concept: Optional["Concept"] = None,
+    ) -> None:
+        self.litheral: str = litheral
+        self.concept: Optional["Concept"] = concept
+        self._links: List["Link"] = []
+        self._markers: List["Marker"] = []
+        # Map[concept -> TypedMarker]
+        self.activation: Dict["Concept", "TypedMarker"] = {}
+        self.pulse_count: int = 0
+
+    def get_links(self) -> List["Link"]:
+        return self._links
+
+    def get_markers(self) -> List["Marker"]:
+        return self._markers
+
+    def check_thresholds(self, marker_classes: object = None) -> bool:
+        return bool(self.activation)
+
+    def get_cumulative_activation(self) -> float:
+        return sum(m.value for m in self.activation.values())
+
+    def get_cumulative_weighted_activation(self) -> float:
+        total = 0.0
+        for concept, marker in self.activation.items():
+            total += marker.value / _C_T
+        return total
+
+    def in_function(self, input_steps: Collection[SpreadingStep]) -> None:
+        from ..markers.typed_marker import TypedMarker
+        for step in input_steps:
+            for marker in step.markings:
+                if isinstance(marker, TypedMarker) and marker.origin is not None:
+                    existing = self.activation.get(marker.origin)
+                    if existing is None:
+                        self.activation[marker.origin] = TypedMarker(
+                            value=marker.value, origin=marker.origin, marker_type=marker.type
+                        )
+                    else:
+                        existing.value += marker.value
+
+    def out_function(self) -> Collection[SpreadingStep]:
+        from ..markers.typed_marker import TypedMarker
+        steps: List[SpreadingStep] = []
+        for link in self._links:
+            from ..links.weighted_link import WeightedLink
+            if not isinstance(link, WeightedLink):
+                continue
+            for concept, marker in self.activation.items():
+                new_val = marker.value * link.weight
+                new_marker = TypedMarker(value=new_val, origin=concept, marker_type=marker.type)
+                step = SpreadingStep()
+                step.link = link
+                step.in_direction = True
+                step.markings = [new_marker]
+                steps.append(step)
+        return steps
+
+    def __repr__(self) -> str:
+        return f"TypedNode({self.litheral!r})"
+
+    def __hash__(self) -> int:
+        return hash(self.litheral)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TypedNode):
+            return NotImplemented
+        return self.litheral == other.litheral

--- a/semantic_decomposition/entities/prime.py
+++ b/semantic_decomposition/entities/prime.py
@@ -1,0 +1,5 @@
+from .entity import Entity
+
+
+class Prime(Entity):
+    """A semantic prime — a basic, undefinable concept."""

--- a/semantic_decomposition/entities/relations/__init__.py
+++ b/semantic_decomposition/entities/relations/__init__.py
@@ -1,0 +1,5 @@
+from .relation import Relation
+from .role import Role
+from .synonym import Synonym
+
+__all__ = ["Relation", "Role", "Synonym"]

--- a/semantic_decomposition/entities/relations/relation.py
+++ b/semantic_decomposition/entities/relations/relation.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+from typing import List, TYPE_CHECKING
+
+from ..entity import Entity
+
+if TYPE_CHECKING:
+    from .role import Role
+
+
+class Relation(Entity):
+    def __init__(self, name: str = "") -> None:
+        super().__init__(name)
+        self.roles: List["Role"] = []
+
+    def is_relationship(self) -> bool:
+        return True

--- a/semantic_decomposition/entities/relations/role.py
+++ b/semantic_decomposition/entities/relations/role.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+
+from .relation import Relation
+
+if TYPE_CHECKING:
+    from ..entity import Entity
+
+
+class Role(Relation):
+    def __init__(self, name: str = "") -> None:
+        super().__init__(name)
+        self.source: Optional["Entity"] = None
+        self.target: Optional["Entity"] = None

--- a/semantic_decomposition/entities/relations/synonym.py
+++ b/semantic_decomposition/entities/relations/synonym.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from typing import List, Optional, TYPE_CHECKING
+
+from .relation import Relation
+
+if TYPE_CHECKING:
+    from ..entity import Entity
+
+
+class Synonym(Relation):
+    def __init__(self, name: str = "") -> None:
+        super().__init__(name)
+        self.entity: Optional["Entity"] = None
+        self.sememe: List["Entity"] = []

--- a/semantic_decomposition/entities/spreading_activation/__init__.py
+++ b/semantic_decomposition/entities/spreading_activation/__init__.py
@@ -1,0 +1,4 @@
+from .marker_passing_config import MarkerPassingConfig
+from .typed_marker_passing_config import TypedMarkerPassingConfig
+
+__all__ = ["MarkerPassingConfig", "TypedMarkerPassingConfig"]

--- a/semantic_decomposition/entities/spreading_activation/marker_passing_config.py
+++ b/semantic_decomposition/entities/spreading_activation/marker_passing_config.py
@@ -1,0 +1,39 @@
+class MarkerPassingConfig:
+    """Static configuration for link weights and spreading activation parameters."""
+
+    start_activation: float = 1.0
+    threshold: float = 0.064
+    termination_pulse_count: int = 80
+    double_activation_limit: int = 20
+    decomposition_depth: int = 1
+
+    _definition_link_weight: float = -0.78
+    _synonym_link_weight: float = 0.62
+    _hypernym_link_weight: float = -0.02
+    _hyponym_link_weight: float = 0.79
+    _antonym_link_weight: float = -0.9
+    _arbitrary_relation_link_weight: float = 0.0
+
+    @classmethod
+    def get_definition_link_weight(cls) -> float:
+        return cls._definition_link_weight
+
+    @classmethod
+    def get_synonym_link_weight(cls) -> float:
+        return cls._synonym_link_weight
+
+    @classmethod
+    def get_hypernym_link_weight(cls) -> float:
+        return cls._hypernym_link_weight
+
+    @classmethod
+    def get_hyponym_link_weight(cls) -> float:
+        return cls._hyponym_link_weight
+
+    @classmethod
+    def get_antonym_link_weight(cls) -> float:
+        return cls._antonym_link_weight
+
+    @classmethod
+    def get_arbitrary_relation_link_weight(cls) -> float:
+        return cls._arbitrary_relation_link_weight

--- a/semantic_decomposition/entities/spreading_activation/typed_marker_passing_config.py
+++ b/semantic_decomposition/entities/spreading_activation/typed_marker_passing_config.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+from typing import Any
+
+
+class TypedMarkerPassingConfig:
+    """All hyper-parameters for the typed marker-passing algorithm."""
+
+    NUMBER_OF_PARAMETERS: int = 12
+
+    def __init__(self) -> None:
+        self.termination_pulse_count: int = 20
+        self.initial_marker_amount: float = 1000.0
+        self.decomposition_depth: int = 2
+
+        self.synonym_weight: float = 0.62
+        self.antonym_weight: float = -0.9
+        self.definition_weight: float = -0.78
+        self.hypernym_weight: float = -0.02
+        self.hyponym_weight: float = 0.79
+        self.meronym_weight: float = 0.5
+
+        self.synonym_threshold: float = 0.064
+        self.antonym_threshold: float = 0.064
+        self.definition_threshold: float = 0.064
+
+    def swap(self) -> "TypedMarkerPassingConfig":
+        swapped = TypedMarkerPassingConfig()
+        swapped.synonym_weight = self.antonym_weight
+        swapped.antonym_weight = self.synonym_weight
+        return swapped
+
+    def get(self, index: int) -> Any:
+        params = [
+            self.termination_pulse_count,
+            self.initial_marker_amount,
+            self.decomposition_depth,
+            self.synonym_weight,
+            self.antonym_weight,
+            self.definition_weight,
+            self.hypernym_weight,
+            self.hyponym_weight,
+            self.meronym_weight,
+            self.synonym_threshold,
+            self.antonym_threshold,
+            self.definition_threshold,
+        ]
+        return params[index]
+
+    def get_number_of_parameters(self) -> int:
+        return self.NUMBER_OF_PARAMETERS

--- a/semantic_decomposition/exceptions/__init__.py
+++ b/semantic_decomposition/exceptions/__init__.py
@@ -1,0 +1,3 @@
+from .dictionary_does_not_contain_concept_exception import DictionaryDoesNotContainConceptException
+
+__all__ = ["DictionaryDoesNotContainConceptException"]

--- a/semantic_decomposition/exceptions/dictionary_does_not_contain_concept_exception.py
+++ b/semantic_decomposition/exceptions/dictionary_does_not_contain_concept_exception.py
@@ -1,0 +1,4 @@
+class DictionaryDoesNotContainConceptException(Exception):
+    def __init__(self, concept_name: str) -> None:
+        super().__init__(f"Dictionary does not contain concept: {concept_name}")
+        self.concept_name = concept_name

--- a/semantic_decomposition/graph/__init__.py
+++ b/semantic_decomposition/graph/__init__.py
@@ -1,0 +1,4 @@
+from .semantic_net import SemanticNet
+from .graph_util import GraphUtil
+
+__all__ = ["SemanticNet", "GraphUtil"]

--- a/semantic_decomposition/graph/edges/__init__.py
+++ b/semantic_decomposition/graph/edges/__init__.py
@@ -1,0 +1,4 @@
+from .edge_type import EdgeType
+from .weighted_edge import WeightedEdge
+
+__all__ = ["EdgeType", "WeightedEdge"]

--- a/semantic_decomposition/graph/edges/edge_type.py
+++ b/semantic_decomposition/graph/edges/edge_type.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class EdgeType(Enum):
+    Synonym = "Synonym"
+    Antonym = "Antonym"
+    Definition = "Definition"
+    Hypernym = "Hypernym"
+    Hyponym = "Hyponym"
+    Meronym = "Meronym"
+    Arbitrary = "Arbitrary"
+    Unknown = "Unknown"

--- a/semantic_decomposition/graph/edges/weighted_edge.py
+++ b/semantic_decomposition/graph/edges/weighted_edge.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+from typing import Any, Dict, Optional
+
+from .edge_type import EdgeType
+
+
+class WeightedEdge:
+    """Graph edge carrying a type, weight, and arbitrary attributes."""
+
+    def __init__(
+        self,
+        source: Any = None,
+        target: Any = None,
+        edge_type: EdgeType = EdgeType.Unknown,
+        weight: float = 1.0,
+    ) -> None:
+        self._source = source
+        self._target = target
+        self.edge_type: EdgeType = edge_type
+        self._weight: float = weight
+        self.attributes: Dict[str, Any] = {}
+
+    @property
+    def source(self) -> Any:
+        return self._source
+
+    @property
+    def target(self) -> Any:
+        return self._target
+
+    def get_edge_weight(self) -> float:
+        return self._weight
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, WeightedEdge):
+            return NotImplemented
+        return self._source == other._source and self._target == other._target
+
+    def __hash__(self) -> int:
+        return hash((self._source, self._target))
+
+    def __repr__(self) -> str:
+        return f"WeightedEdge({self._source!r} -[{self.edge_type.value}]-> {self._target!r})"

--- a/semantic_decomposition/graph/graph_util.py
+++ b/semantic_decomposition/graph/graph_util.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+import os
+import pickle
+from pathlib import Path
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
+
+from .semantic_net import SemanticNet
+from .edges.weighted_edge import WeightedEdge
+from .edges.edge_type import EdgeType
+
+if TYPE_CHECKING:
+    from ..concept import Concept
+    from ..word_type import WordType
+
+_GRAPH_CACHE: Dict[Tuple[str, str, int], SemanticNet] = {}
+_GRAPH_STORE_DIR = Path.home() / ".decomposition" / "graphs"
+
+
+class GraphUtil:
+    """Static utility for building and merging SemanticNet graphs from concepts."""
+
+    @staticmethod
+    def create_graph(concept: "Concept") -> SemanticNet:
+        graph = SemanticNet()
+        graph.add_vertex(concept)
+        GraphUtil._add_relation_edges(graph, concept, concept.synonyms, EdgeType.Synonym)
+        GraphUtil._add_relation_edges(graph, concept, concept.antonyms, EdgeType.Antonym)
+        GraphUtil._add_relation_edges(graph, concept, concept.hypernyms, EdgeType.Hypernym)
+        GraphUtil._add_relation_edges(graph, concept, concept.hyponyms, EdgeType.Hyponym)
+        GraphUtil._add_relation_edges(graph, concept, concept.meronyms, EdgeType.Meronym)
+        for rel_name, related in concept.arbitrary_relations.items():
+            GraphUtil._add_relation_edges(graph, concept, related, EdgeType.Arbitrary)
+        for definition in concept.definitions:
+            if hasattr(definition, "concepts"):
+                for def_concept in definition.concepts:
+                    edge = WeightedEdge(concept, def_concept, EdgeType.Definition)
+                    graph.add_edge(concept, def_concept, edge)
+        return graph
+
+    @staticmethod
+    def _add_relation_edges(
+        graph: SemanticNet,
+        source: "Concept",
+        targets: list,
+        edge_type: EdgeType,
+    ) -> None:
+        for target in targets:
+            edge = WeightedEdge(source, target, edge_type)
+            graph.add_edge(source, target, edge)
+
+    @staticmethod
+    def merge_graph(g1: SemanticNet, g2: SemanticNet) -> SemanticNet:
+        merged = SemanticNet()
+        for node in g1.vertex_set():
+            merged.add_vertex(node)
+        for node in g2.vertex_set():
+            merged.add_vertex(node)
+        for edge in g1.edge_set():
+            merged.add_edge(edge.source, edge.target, edge)
+        for edge in g2.edge_set():
+            if not merged.contains_edge(edge):
+                merged.add_edge(edge.source, edge.target, edge)
+        return merged
+
+    @staticmethod
+    def get_graph(word: str, word_type: "WordType", depth: int) -> SemanticNet:
+        key = (word, str(word_type), depth)
+        if key in _GRAPH_CACHE:
+            return _GRAPH_CACHE[key]
+        loaded = GraphUtil._load_graph(word, word_type, depth)
+        if loaded is not None:
+            _GRAPH_CACHE[key] = loaded
+            return loaded
+        return SemanticNet()
+
+    @staticmethod
+    def save_graph(graph: SemanticNet, word: str, word_type: "WordType", depth: int) -> None:
+        _GRAPH_STORE_DIR.mkdir(parents=True, exist_ok=True)
+        path = _GRAPH_STORE_DIR / f"{word}_{word_type}_{depth}.pkl"
+        with open(path, "wb") as f:
+            pickle.dump(graph, f)
+        key = (word, str(word_type), depth)
+        _GRAPH_CACHE[key] = graph
+
+    @staticmethod
+    def _load_graph(word: str, word_type: "WordType", depth: int) -> Optional[SemanticNet]:
+        path = _GRAPH_STORE_DIR / f"{word}_{word_type}_{depth}.pkl"
+        if not path.exists():
+            return None
+        try:
+            with open(path, "rb") as f:
+                return pickle.load(f)
+        except Exception:
+            return None

--- a/semantic_decomposition/graph/semantic_net.py
+++ b/semantic_decomposition/graph/semantic_net.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from .edges.weighted_edge import WeightedEdge
+from .edges.edge_type import EdgeType
+
+
+class SemanticNet:
+    """
+    Directed graph representing a semantic network.
+
+    Replaces JGraphT DefaultListenableGraph<Entity, Relation>.
+    Nodes can be any hashable object (typically Entity / Concept).
+    Edges are WeightedEdge instances.
+    """
+
+    def __init__(self) -> None:
+        self._nodes: Set[Any] = set()
+        self._edges: List[WeightedEdge] = []
+        self._out_edges: Dict[Any, List[WeightedEdge]] = {}
+        self._in_edges: Dict[Any, List[WeightedEdge]] = {}
+
+    def add_vertex(self, node: Any) -> None:
+        self._nodes.add(node)
+        self._out_edges.setdefault(node, [])
+        self._in_edges.setdefault(node, [])
+
+    def add_edge(self, source: Any, target: Any, edge: WeightedEdge) -> None:
+        self.add_vertex(source)
+        self.add_vertex(target)
+        self._edges.append(edge)
+        self._out_edges[source].append(edge)
+        self._in_edges[target].append(edge)
+
+    def contains_vertex(self, node: Any) -> bool:
+        return node in self._nodes
+
+    def contains_edge(self, edge: WeightedEdge) -> bool:
+        return edge in self._edges
+
+    def vertex_set(self) -> Set[Any]:
+        return set(self._nodes)
+
+    def edge_set(self) -> List[WeightedEdge]:
+        return list(self._edges)
+
+    def edges_of(self, node: Any) -> List[WeightedEdge]:
+        return self._out_edges.get(node, []) + self._in_edges.get(node, [])
+
+    def out_edges_of(self, node: Any) -> List[WeightedEdge]:
+        return self._out_edges.get(node, [])
+
+    def get_edge_source(self, edge: WeightedEdge) -> Any:
+        return edge.source
+
+    def get_edge_target(self, edge: WeightedEdge) -> Any:
+        return edge.target
+
+    def get_edge_weight(self, edge: WeightedEdge) -> float:
+        return edge.get_edge_weight()

--- a/semantic_decomposition/graph/spreading_activation/__init__.py
+++ b/semantic_decomposition/graph/spreading_activation/__init__.py
@@ -1,0 +1,4 @@
+from .count_termination_condition import CountTerminationCondition
+from .double_spreading_activation import DoubleSpreadingActivation
+
+__all__ = ["CountTerminationCondition", "DoubleSpreadingActivation"]

--- a/semantic_decomposition/graph/spreading_activation/count_termination_condition.py
+++ b/semantic_decomposition/graph/spreading_activation/count_termination_condition.py
@@ -1,0 +1,23 @@
+from ...marker_passing.processing_step import ProcessingStep
+from ...marker_passing.termination_condition import TerminationCondition
+
+
+class CountTerminationCondition(ProcessingStep, TerminationCondition):
+    """Counts pulses and terminates after a configurable maximum."""
+
+    def __init__(self, max_pulses: int = 80) -> None:
+        self._max_pulses = max_pulses
+        self._count = 0
+
+    @property
+    def count(self) -> int:
+        return self._count
+
+    def execute(self) -> None:
+        self._count += 1
+
+    def compute(self) -> bool:
+        return self._count >= self._max_pulses
+
+    def reset(self) -> None:
+        self._count = 0

--- a/semantic_decomposition/graph/spreading_activation/double_spreading_activation.py
+++ b/semantic_decomposition/graph/spreading_activation/double_spreading_activation.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+from typing import Collection, Dict, List, Optional, TYPE_CHECKING
+
+from ...marker_passing.spreading_algorithm import SpreadingAlgorithm
+from ...marker_passing.spreading_step import SpreadingStep
+from ...marker_passing.in_function import InFunction
+from ...marker_passing.out_function import OutFunction
+from ...marker_passing.select_firing_nodes_function import SelectFiringNodesFunction
+from ...marker_passing.node import Node
+from ..semantic_net import SemanticNet
+from .count_termination_condition import CountTerminationCondition
+
+if TYPE_CHECKING:
+    from ...concept import Concept
+    from ...entities.spreading_activation.marker_passing_config import MarkerPassingConfig
+
+
+class _AllNodesSelect(SelectFiringNodesFunction):
+    def compute(self, active_nodes: Collection[Node]) -> Collection[Node]:
+        return active_nodes
+
+
+class _DoubleIn(InFunction):
+    def compute(self, input_steps: Collection[SpreadingStep], node: Node) -> None:
+        if hasattr(node, "in_function"):
+            node.in_function(input_steps)
+
+
+class _DoubleOut(OutFunction):
+    def compute(self, node: Node) -> Collection[SpreadingStep]:
+        if hasattr(node, "out_function"):
+            return node.out_function()
+        return []
+
+
+class DoubleSpreadingActivation(SpreadingAlgorithm):
+    """Spreading activation over a SemanticNet using DoubleNode nodes."""
+
+    def __init__(
+        self,
+        graph: SemanticNet,
+        config: Optional["MarkerPassingConfig"] = None,
+    ) -> None:
+        super().__init__()
+        self._graph = graph
+        self._config = config
+        termination = CountTerminationCondition(
+            config.termination_pulse_count if config else 80
+        )
+        self.termination_condition = termination
+        self.preprocessing_steps = [termination]
+        self.in_function = _DoubleIn()
+        self.out_function = _DoubleOut()
+        self.select_firing_nodes = _AllNodesSelect()
+
+    def do_initial_marking(self, concepts: List["Concept"]) -> None:
+        from ...entities.nodes.double_node import DoubleNode
+        from ...entities.markers.double_marker import DoubleMarker
+        from ...entities.spreading_activation.marker_passing_config import MarkerPassingConfig
+
+        start = (
+            self._config.start_activation
+            if self._config
+            else MarkerPassingConfig.start_activation
+        )
+        for node in self._active_nodes:
+            if isinstance(node, DoubleNode) and node.concept in concepts:
+                node.activation = start
+                node.add_marker(DoubleMarker(start))

--- a/semantic_decomposition/graph/spreading_activation/marker_passing/__init__.py
+++ b/semantic_decomposition/graph/spreading_activation/marker_passing/__init__.py
@@ -1,0 +1,9 @@
+from .double_marker_passing import DoubleMarkerPassing
+from .typed_marker_passing import TypedMarkerPassing
+from .marker_passing_semantic_distance_measure import MarkerPassingSemanticDistanceMeasure
+
+__all__ = [
+    "DoubleMarkerPassing",
+    "TypedMarkerPassing",
+    "MarkerPassingSemanticDistanceMeasure",
+]

--- a/semantic_decomposition/graph/spreading_activation/marker_passing/double_marker_passing.py
+++ b/semantic_decomposition/graph/spreading_activation/marker_passing/double_marker_passing.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+from typing import Collection, Dict, List, Optional, Set, TYPE_CHECKING
+
+from ....marker_passing.spreading_algorithm import SpreadingAlgorithm
+from ....marker_passing.spreading_step import SpreadingStep
+from ....marker_passing.in_function import InFunction
+from ....marker_passing.out_function import OutFunction
+from ....marker_passing.select_firing_nodes_function import SelectFiringNodesFunction
+from ....marker_passing.node import Node
+from ...semantic_net import SemanticNet
+from ..count_termination_condition import CountTerminationCondition
+
+if TYPE_CHECKING:
+    from ....concept import Concept
+    from ....entities.spreading_activation.marker_passing_config import MarkerPassingConfig
+
+
+class _FireThresholdNodes(SelectFiringNodesFunction):
+    def __init__(self, config: Optional["MarkerPassingConfig"]) -> None:
+        self._config = config
+
+    def compute(self, active_nodes: Collection[Node]) -> Collection[Node]:
+        from ....entities.nodes.double_node_with_multiple_thresholds import (
+            DoubleNodeWithMultipleThresholds,
+        )
+        result = []
+        for node in active_nodes:
+            if isinstance(node, DoubleNodeWithMultipleThresholds):
+                if node.check_thresholds():
+                    result.append(node)
+        return result
+
+
+class _DoubleMultiIn(InFunction):
+    def compute(self, input_steps: Collection[SpreadingStep], node: Node) -> None:
+        if hasattr(node, "in_function"):
+            node.in_function(input_steps)
+
+
+class _DoubleMultiOut(OutFunction):
+    def compute(self, node: Node) -> Collection[SpreadingStep]:
+        if hasattr(node, "out_function"):
+            return node.out_function()
+        return []
+
+
+class DoubleMarkerPassing(SpreadingAlgorithm):
+    """
+    Marker-passing algorithm using DoubleNodeWithMultipleThresholds nodes.
+
+    Replaces the JGraphT-backed Java implementation; uses SemanticNet instead.
+    """
+
+    def __init__(
+        self,
+        config: Optional["MarkerPassingConfig"] = None,
+    ) -> None:
+        super().__init__()
+        from ....entities.spreading_activation.marker_passing_config import MarkerPassingConfig
+        self._config = config or MarkerPassingConfig()
+        self._graph: SemanticNet = SemanticNet()
+        # Bidirectional map: Concept <-> Node
+        self._concept_to_node: Dict["Concept", Node] = {}
+        self._node_to_concept: Dict[Node, "Concept"] = {}
+
+        termination = CountTerminationCondition(self._config.termination_pulse_count)
+        self.termination_condition = termination
+        self.preprocessing_steps = [termination]
+        self.in_function = _DoubleMultiIn()
+        self.out_function = _DoubleMultiOut()
+        self.select_firing_nodes = _FireThresholdNodes(self._config)
+
+    def fill_nodes(self, concepts: List["Concept"]) -> None:
+        for concept in concepts:
+            self._add_concept_recursively(concept, self._config.decomposition_depth)
+        self._active_nodes = list(self._concept_to_node.values())
+
+    def _add_concept_recursively(self, concept: "Concept", depth: int) -> Node:
+        if concept in self._concept_to_node:
+            return self._concept_to_node[concept]
+
+        from ....entities.nodes.double_node_with_multiple_thresholds import (
+            DoubleNodeWithMultipleThresholds,
+        )
+        node = DoubleNodeWithMultipleThresholds(
+            litheral=concept.litheral, concept=concept, config=self._config
+        )
+        self._concept_to_node[concept] = node
+        self._node_to_concept[node] = concept
+        self._graph.add_vertex(node)
+
+        if depth <= 0:
+            return node
+
+        self._connect_related(concept, concept.synonyms, "SynonymLink", depth)
+        self._connect_related(concept, concept.antonyms, "AntonymLink", depth)
+        self._connect_related(concept, concept.hypernyms, "HypernymLink", depth)
+        self._connect_related(concept, concept.hyponyms, "HyponymLink", depth)
+        self._connect_related(concept, concept.meronyms, "WeightedLink", depth)
+        for definition in concept.definitions:
+            if hasattr(definition, "concepts"):
+                self._connect_related(concept, definition.concepts, "DefinitionLink", depth)
+        return node
+
+    def _connect_related(
+        self,
+        source_concept: "Concept",
+        related: List["Concept"],
+        link_class: str,
+        depth: int,
+    ) -> None:
+        from ....entities.links import (
+            SynonymLink, AntonymLink, HypernymLink, HyponymLink, DefinitionLink, WeightedLink,
+        )
+        link_map = {
+            "SynonymLink": SynonymLink,
+            "AntonymLink": AntonymLink,
+            "HypernymLink": HypernymLink,
+            "HyponymLink": HyponymLink,
+            "DefinitionLink": DefinitionLink,
+            "WeightedLink": WeightedLink,
+        }
+        LinkClass = link_map.get(link_class, WeightedLink)
+        source_node = self._concept_to_node[source_concept]
+        for target_concept in related:
+            target_node = self._add_concept_recursively(target_concept, depth - 1)
+            link = LinkClass(source=source_node, target=target_node, config=self._config)
+            if link not in source_node.get_links():
+                source_node.get_links().append(link)
+
+    @staticmethod
+    def do_initial_marking(
+        nodes: Dict["Concept", Node],
+        concepts: List["Concept"],
+        start_activation: float,
+    ) -> None:
+        from ....entities.markers.double_marker_with_origin import DoubleMarkerWithOrigin
+        for concept in concepts:
+            node = nodes.get(concept)
+            if node is not None:
+                marker = DoubleMarkerWithOrigin(
+                    activation=start_activation, origin=concept
+                )
+                node.add_marker(marker)
+                from ....entities.nodes.double_node_with_multiple_thresholds import (
+                    DoubleNodeWithMultipleThresholds,
+                )
+                if isinstance(node, DoubleNodeWithMultipleThresholds):
+                    node.activation[concept][start_activation].append(concept)

--- a/semantic_decomposition/graph/spreading_activation/marker_passing/marker_passing_semantic_distance_measure.py
+++ b/semantic_decomposition/graph/spreading_activation/marker_passing/marker_passing_semantic_distance_measure.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+from typing import List, TYPE_CHECKING
+
+from ....i_concept import IConcept
+from ....distance.semantic_distance_measure import SemanticDistanceMeasureInterface
+from .double_marker_passing import DoubleMarkerPassing
+
+if TYPE_CHECKING:
+    from ....concept import Concept
+    from ....entities.spreading_activation.marker_passing_config import MarkerPassingConfig
+
+
+class MarkerPassingSemanticDistanceMeasure(SemanticDistanceMeasureInterface):
+    """
+    Computes semantic similarity between two words using DoubleMarkerPassing.
+
+    Algorithm:
+    1. Decompose both words into concept graphs.
+    2. Merge the two graphs.
+    3. Run DoubleMarkerPassing with the two initial concepts marked.
+    4. Return summed double activation / (2 * start_activation).
+    """
+
+    def __init__(
+        self,
+        config: "MarkerPassingConfig | None" = None,
+    ) -> None:
+        from ....entities.spreading_activation.marker_passing_config import MarkerPassingConfig
+        self._config = config or MarkerPassingConfig()
+
+    def compare_concepts(self, c1: IConcept, c2: IConcept) -> float:
+        from ....concept import Concept
+        if not isinstance(c1, Concept) or not isinstance(c2, Concept):
+            raise TypeError("Both arguments must be Concept instances")
+        return self.pass_marker(c1, c2)
+
+    def pass_marker(self, c1: "Concept", c2: "Concept") -> float:
+        algorithm = DoubleMarkerPassing(config=self._config)
+        algorithm.fill_nodes([c1, c2])
+
+        start = self._config.start_activation
+        DoubleMarkerPassing.do_initial_marking(
+            algorithm._concept_to_node, [c1, c2], start
+        )
+
+        algorithm.execute()
+
+        return self._compute_similarity(algorithm, start)
+
+    def _compute_similarity(
+        self,
+        algorithm: DoubleMarkerPassing,
+        start_activation: float,
+    ) -> float:
+        from ....entities.nodes.double_node_with_multiple_thresholds import (
+            DoubleNodeWithMultipleThresholds,
+        )
+        total = 0.0
+        for node in algorithm.active_nodes:
+            if isinstance(node, DoubleNodeWithMultipleThresholds):
+                for act_map in node.activation.values():
+                    for act_val in act_map:
+                        total += abs(act_val)
+        denominator = 2.0 * start_activation
+        return total / denominator if denominator != 0 else 0.0

--- a/semantic_decomposition/graph/spreading_activation/marker_passing/typed_marker_passing.py
+++ b/semantic_decomposition/graph/spreading_activation/marker_passing/typed_marker_passing.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+from typing import Collection, Dict, List, Optional, TYPE_CHECKING
+
+from ....marker_passing.spreading_algorithm import SpreadingAlgorithm
+from ....marker_passing.spreading_step import SpreadingStep
+from ....marker_passing.in_function import InFunction
+from ....marker_passing.out_function import OutFunction
+from ....marker_passing.select_firing_nodes_function import SelectFiringNodesFunction
+from ....marker_passing.node import Node
+from ...semantic_net import SemanticNet
+from ..count_termination_condition import CountTerminationCondition
+
+if TYPE_CHECKING:
+    from ....concept import Concept
+    from ....entities.spreading_activation.typed_marker_passing_config import (
+        TypedMarkerPassingConfig,
+    )
+
+
+class _AllActiveSelect(SelectFiringNodesFunction):
+    def compute(self, active_nodes: Collection[Node]) -> Collection[Node]:
+        return [n for n in active_nodes if n.check_thresholds()]
+
+
+class _TypedIn(InFunction):
+    def compute(self, input_steps: Collection[SpreadingStep], node: Node) -> None:
+        if hasattr(node, "in_function"):
+            node.in_function(input_steps)
+
+
+class _TypedOut(OutFunction):
+    def compute(self, node: Node) -> Collection[SpreadingStep]:
+        if hasattr(node, "out_function"):
+            return node.out_function()
+        return []
+
+
+class TypedMarkerPassing(SpreadingAlgorithm):
+    """Marker-passing algorithm using TypedNode nodes and TypedMarkerPassingConfig."""
+
+    def __init__(
+        self,
+        config: Optional["TypedMarkerPassingConfig"] = None,
+    ) -> None:
+        super().__init__()
+        from ....entities.spreading_activation.typed_marker_passing_config import (
+            TypedMarkerPassingConfig,
+        )
+        self._config = config or TypedMarkerPassingConfig()
+        self._graph: SemanticNet = SemanticNet()
+        self._concept_to_node: Dict["Concept", Node] = {}
+
+        termination = CountTerminationCondition(self._config.termination_pulse_count)
+        self.termination_condition = termination
+        self.preprocessing_steps = [termination]
+        self.in_function = _TypedIn()
+        self.out_function = _TypedOut()
+        self.select_firing_nodes = _AllActiveSelect()
+
+    def set_initial_concepts(self, concepts: List["Concept"]) -> None:
+        for concept in concepts:
+            self._add_concept_recursively(concept, self._config.decomposition_depth)
+        self._active_nodes = list(self._concept_to_node.values())
+
+    def _add_concept_recursively(self, concept: "Concept", depth: int) -> Node:
+        if concept in self._concept_to_node:
+            return self._concept_to_node[concept]
+        from ....entities.nodes.typed_node import TypedNode
+        node = TypedNode(litheral=concept.litheral, concept=concept)
+        self._concept_to_node[concept] = node
+        self._graph.add_vertex(node)
+        if depth > 0:
+            self._connect_related(concept, concept.synonyms, self._config.synonym_weight, depth)
+            self._connect_related(concept, concept.antonyms, self._config.antonym_weight, depth)
+            self._connect_related(concept, concept.hypernyms, self._config.hypernym_weight, depth)
+            self._connect_related(concept, concept.hyponyms, self._config.hyponym_weight, depth)
+            self._connect_related(concept, concept.meronyms, self._config.meronym_weight, depth)
+        return node
+
+    def _connect_related(
+        self,
+        source_concept: "Concept",
+        related: List["Concept"],
+        weight: float,
+        depth: int,
+    ) -> None:
+        from ....entities.links.weighted_link import WeightedLink
+        source_node = self._concept_to_node[source_concept]
+        for target_concept in related:
+            target_node = self._add_concept_recursively(target_concept, depth - 1)
+            link = WeightedLink(source=source_node, target=target_node, weight=weight)
+            if link not in source_node.get_links():
+                source_node.get_links().append(link)
+
+    def get_definition_of_initial_concepts(self) -> List["Concept"]:
+        result: List["Concept"] = []
+        for concept in self._concept_to_node:
+            for definition in concept.definitions:
+                if hasattr(definition, "concepts"):
+                    result.extend(definition.concepts)
+        return result
+
+    def start(self, initial_concepts: List["Concept"]) -> None:
+        from ....entities.markers.typed_marker import TypedMarker
+        for concept in initial_concepts:
+            node = self._concept_to_node.get(concept)
+            if node is not None:
+                marker = TypedMarker(
+                    value=self._config.initial_marker_amount, origin=concept, marker_type=0
+                )
+                node.add_marker(marker)
+                from ....entities.nodes.typed_node import TypedNode
+                if isinstance(node, TypedNode):
+                    node.activation[concept] = marker
+        self.execute()

--- a/semantic_decomposition/i_concept.py
+++ b/semantic_decomposition/i_concept.py
@@ -1,0 +1,2 @@
+class IConcept:
+    """Marker interface for concepts used in semantic distance measures."""

--- a/semantic_decomposition/marker_passing/__init__.py
+++ b/semantic_decomposition/marker_passing/__init__.py
@@ -1,0 +1,17 @@
+from .marker import Marker
+from .link import Link
+from .node import Node
+from .spreading_step import SpreadingStep
+from .spreaded_markers import SpreadedMarkers
+from .in_function import InFunction
+from .out_function import OutFunction
+from .select_firing_nodes_function import SelectFiringNodesFunction
+from .processing_step import ProcessingStep
+from .termination_condition import TerminationCondition
+from .spreading_algorithm import SpreadingAlgorithm
+
+__all__ = [
+    "Marker", "Link", "Node", "SpreadingStep", "SpreadedMarkers",
+    "InFunction", "OutFunction", "SelectFiringNodesFunction",
+    "ProcessingStep", "TerminationCondition", "SpreadingAlgorithm",
+]

--- a/semantic_decomposition/marker_passing/in_function.py
+++ b/semantic_decomposition/marker_passing/in_function.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import Collection, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .spreading_step import SpreadingStep
+    from .node import Node
+
+
+class InFunction(ABC):
+    @abstractmethod
+    def compute(self, input_steps: Collection["SpreadingStep"], node: "Node") -> None: ...

--- a/semantic_decomposition/marker_passing/link.py
+++ b/semantic_decomposition/marker_passing/link.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .node import Node
+
+
+class Link(ABC):
+    """Directed edge with a source and a target node."""
+
+    @property
+    @abstractmethod
+    def source(self) -> "Node": ...
+
+    @source.setter
+    @abstractmethod
+    def source(self, value: "Node") -> None: ...
+
+    @property
+    @abstractmethod
+    def target(self) -> "Node": ...
+
+    @target.setter
+    @abstractmethod
+    def target(self, value: "Node") -> None: ...

--- a/semantic_decomposition/marker_passing/marker.py
+++ b/semantic_decomposition/marker_passing/marker.py
@@ -1,0 +1,5 @@
+from abc import ABC
+
+
+class Marker(ABC):
+    """General data type passed from one node to another."""

--- a/semantic_decomposition/marker_passing/node.py
+++ b/semantic_decomposition/marker_passing/node.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .link import Link
+    from .marker import Marker
+
+
+class Node(ABC):
+    """Vertex in the graph that holds markers and connects via links."""
+
+    def add_link(self, link: "Link") -> None:
+        self.get_links().append(link)
+
+    def remove_link(self, link: "Link") -> None:
+        self.get_links().remove(link)
+
+    @abstractmethod
+    def get_links(self) -> List["Link"]: ...
+
+    def add_marker(self, marker: "Marker") -> None:
+        self.get_markers().append(marker)
+
+    def remove_marker(self, marker: "Marker") -> None:
+        self.get_markers().remove(marker)
+
+    @abstractmethod
+    def get_markers(self) -> List["Marker"]: ...
+
+    @abstractmethod
+    def check_thresholds(self, marker_classes: object) -> bool: ...

--- a/semantic_decomposition/marker_passing/out_function.py
+++ b/semantic_decomposition/marker_passing/out_function.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import Collection, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .node import Node
+    from .spreading_step import SpreadingStep
+
+
+class OutFunction(ABC):
+    @abstractmethod
+    def compute(self, node: "Node") -> Collection["SpreadingStep"]: ...

--- a/semantic_decomposition/marker_passing/processing_step.py
+++ b/semantic_decomposition/marker_passing/processing_step.py
@@ -1,0 +1,6 @@
+from abc import ABC, abstractmethod
+
+
+class ProcessingStep(ABC):
+    @abstractmethod
+    def execute(self) -> None: ...

--- a/semantic_decomposition/marker_passing/select_firing_nodes_function.py
+++ b/semantic_decomposition/marker_passing/select_firing_nodes_function.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import Collection, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .node import Node
+
+
+class SelectFiringNodesFunction(ABC):
+    @abstractmethod
+    def compute(self, active_nodes: Collection["Node"]) -> Collection["Node"]: ...

--- a/semantic_decomposition/marker_passing/spreaded_markers.py
+++ b/semantic_decomposition/marker_passing/spreaded_markers.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from collections import defaultdict
+from typing import Collection, Dict, List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .node import Node
+    from .spreading_step import SpreadingStep
+
+
+class SpreadedMarkers:
+    """Spreading steps grouped by target node, ready for in-function processing."""
+
+    def __init__(self) -> None:
+        self._markers: Dict["Node", List["SpreadingStep"]] = defaultdict(list)
+
+    def add_all(self, steps: Collection["SpreadingStep"]) -> None:
+        for step in steps:
+            self._markers[step.get_target_node()].append(step)
+
+    def get_target_nodes(self) -> Collection["Node"]:
+        return self._markers.keys()
+
+    def get_input_for_target(self, target: "Node") -> List["SpreadingStep"]:
+        return self._markers[target]

--- a/semantic_decomposition/marker_passing/spreading_algorithm.py
+++ b/semantic_decomposition/marker_passing/spreading_algorithm.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+from typing import Collection, List, Optional, TYPE_CHECKING
+
+from .spreaded_markers import SpreadedMarkers
+
+if TYPE_CHECKING:
+    from .node import Node
+    from .in_function import InFunction
+    from .out_function import OutFunction
+    from .select_firing_nodes_function import SelectFiringNodesFunction
+    from .termination_condition import TerminationCondition
+    from .processing_step import ProcessingStep
+
+
+class SpreadingAlgorithm:
+    """Main marker-passing algorithm. Runs pulses until termination condition is met."""
+
+    def __init__(self) -> None:
+        self._terminate: bool = False
+        self._in: Optional["InFunction"] = None
+        self._out: Optional["OutFunction"] = None
+        self._select_firing_nodes: Optional["SelectFiringNodesFunction"] = None
+        self._termination_condition: Optional["TerminationCondition"] = None
+        self._preprocessing_steps: List["ProcessingStep"] = []
+        self._postprocessing_steps: List["ProcessingStep"] = []
+        self._firing_nodes: List["Node"] = []
+        self._active_nodes: List["Node"] = []
+
+    @property
+    def terminate(self) -> bool:
+        return self._terminate
+
+    @terminate.setter
+    def terminate(self, value: bool) -> None:
+        self._terminate = value
+
+    @property
+    def in_function(self) -> Optional["InFunction"]:
+        return self._in
+
+    @in_function.setter
+    def in_function(self, value: "InFunction") -> None:
+        self._in = value
+
+    @property
+    def out_function(self) -> Optional["OutFunction"]:
+        return self._out
+
+    @out_function.setter
+    def out_function(self, value: "OutFunction") -> None:
+        self._out = value
+
+    @property
+    def select_firing_nodes(self) -> Optional["SelectFiringNodesFunction"]:
+        return self._select_firing_nodes
+
+    @select_firing_nodes.setter
+    def select_firing_nodes(self, value: "SelectFiringNodesFunction") -> None:
+        self._select_firing_nodes = value
+
+    @property
+    def termination_condition(self) -> Optional["TerminationCondition"]:
+        return self._termination_condition
+
+    @termination_condition.setter
+    def termination_condition(self, value: "TerminationCondition") -> None:
+        self._termination_condition = value
+
+    @property
+    def preprocessing_steps(self) -> List["ProcessingStep"]:
+        return self._preprocessing_steps
+
+    @preprocessing_steps.setter
+    def preprocessing_steps(self, value: List["ProcessingStep"]) -> None:
+        self._preprocessing_steps = value
+
+    @property
+    def postprocessing_steps(self) -> List["ProcessingStep"]:
+        return self._postprocessing_steps
+
+    @postprocessing_steps.setter
+    def postprocessing_steps(self, value: List["ProcessingStep"]) -> None:
+        self._postprocessing_steps = value
+
+    @property
+    def firing_nodes(self) -> List["Node"]:
+        return self._firing_nodes
+
+    @firing_nodes.setter
+    def firing_nodes(self, value: List["Node"]) -> None:
+        self._firing_nodes = value
+
+    @property
+    def active_nodes(self) -> List["Node"]:
+        return self._active_nodes
+
+    @active_nodes.setter
+    def active_nodes(self, value: List["Node"]) -> None:
+        self._active_nodes = value
+
+    def execute(self) -> None:
+        self._terminate = False
+        while not self._terminate:
+            self._pulse()
+
+    def _pulse(self) -> Collection["Node"]:
+        self._preprocess()
+        self._firing_nodes = list(self._select_firing_nodes.compute(self._active_nodes))
+        self._spread()
+        self._postprocess()
+        self._check_termination()
+        return self._active_nodes
+
+    def _preprocess(self) -> None:
+        for step in self._preprocessing_steps:
+            step.execute()
+
+    def _spread(self) -> None:
+        spreaded = SpreadedMarkers()
+        for node in self._firing_nodes:
+            spreaded.add_all(self._out.compute(node))
+        self._firing_nodes.clear()
+        for target in spreaded.get_target_nodes():
+            self._in.compute(spreaded.get_input_for_target(target), target)
+            self._active_nodes.append(target)
+
+    def _postprocess(self) -> None:
+        for step in self._postprocessing_steps:
+            step.execute()
+
+    def _check_termination(self) -> None:
+        self._terminate = self._termination_condition.compute()

--- a/semantic_decomposition/marker_passing/spreading_step.py
+++ b/semantic_decomposition/marker_passing/spreading_step.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+from typing import List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .link import Link
+    from .marker import Marker
+    from .node import Node
+
+
+class SpreadingStep:
+    """One activation step within a pulse: a link traversal with markers."""
+
+    def __init__(self) -> None:
+        self._link: Optional["Link"] = None
+        self._in_direction: bool = True
+        self._markings: List["Marker"] = []
+
+    @property
+    def link(self) -> Optional["Link"]:
+        return self._link
+
+    @link.setter
+    def link(self, value: Optional["Link"]) -> None:
+        self._link = value
+
+    @property
+    def in_direction(self) -> bool:
+        return self._in_direction
+
+    @in_direction.setter
+    def in_direction(self, value: bool) -> None:
+        self._in_direction = value
+
+    @property
+    def markings(self) -> List["Marker"]:
+        return self._markings
+
+    @markings.setter
+    def markings(self, value: List["Marker"]) -> None:
+        self._markings = value
+
+    def get_target_node(self) -> Optional["Node"]:
+        if self._link is None:
+            return None
+        return self._link.target if self._in_direction else self._link.source

--- a/semantic_decomposition/marker_passing/termination_condition.py
+++ b/semantic_decomposition/marker_passing/termination_condition.py
@@ -1,0 +1,6 @@
+from abc import ABC, abstractmethod
+
+
+class TerminationCondition(ABC):
+    @abstractmethod
+    def compute(self) -> bool: ...

--- a/semantic_decomposition/persistence/__init__.py
+++ b/semantic_decomposition/persistence/__init__.py
@@ -1,0 +1,3 @@
+from .concept_cache import ConceptCache
+
+__all__ = ["ConceptCache"]

--- a/semantic_decomposition/persistence/concept_cache.py
+++ b/semantic_decomposition/persistence/concept_cache.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+import os
+import pickle
+from pathlib import Path
+from typing import Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..concept import Concept
+
+_CACHE_DIR = Path.home() / ".decomposition" / "ConceptCache"
+
+
+class ConceptCache:
+    """Singleton LRU-style in-memory cache backed by a file-based store."""
+
+    _instance: Optional["ConceptCache"] = None
+
+    def __init__(self, max_size: int = 100) -> None:
+        self._max_size = max_size
+        self._cache: Dict[int, "Concept"] = {}
+        _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        self._cache_file = _CACHE_DIR / "cache.pkl"
+        self._load()
+
+    @classmethod
+    def get_instance(cls) -> "ConceptCache":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def get(self, key: int) -> Optional["Concept"]:
+        return self._cache.get(key)
+
+    def put(self, concept: "Concept") -> None:
+        if len(self._cache) >= self._max_size:
+            oldest = next(iter(self._cache))
+            del self._cache[oldest]
+        self._cache[concept.id] = concept
+
+    def put_all(self, concepts: List["Concept"]) -> None:
+        for concept in concepts:
+            self.put(concept)
+
+    def clean_up(self) -> None:
+        self._save()
+
+    def _load(self) -> None:
+        if self._cache_file.exists():
+            try:
+                with open(self._cache_file, "rb") as f:
+                    self._cache = pickle.load(f)
+            except Exception:
+                self._cache = {}
+
+    def _save(self) -> None:
+        with open(self._cache_file, "wb") as f:
+            pickle.dump(self._cache, f)

--- a/semantic_decomposition/settings/__init__.py
+++ b/semantic_decomposition/settings/__init__.py
@@ -1,0 +1,3 @@
+from .config import Config, Language
+
+__all__ = ["Config", "Language"]

--- a/semantic_decomposition/settings/config.py
+++ b/semantic_decomposition/settings/config.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+import configparser
+import os
+from enum import Enum
+from pathlib import Path
+from typing import List, Optional
+
+
+class Language(Enum):
+    EN = "EN"
+    GER = "GER"
+
+
+_CONFIG_DIR = Path.home() / ".decomposition"
+_CONFIG_FILE = _CONFIG_DIR / "decomposition.cfg"
+
+
+class Config:
+    """Singleton reading from ~/.decomposition/decomposition.cfg."""
+
+    _instance: Optional["Config"] = None
+
+    def __init__(self) -> None:
+        self.language: Language = Language.EN
+        self.wiktionary_path: str = ""
+        self.primes_dir: str = str(_CONFIG_DIR / "primes")
+        self._stop_words: List[str] = []
+        self._load()
+
+    @classmethod
+    def get_instance(cls) -> "Config":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def _load(self) -> None:
+        if not _CONFIG_FILE.exists():
+            return
+        parser = configparser.ConfigParser()
+        parser.read(str(_CONFIG_FILE))
+        section = "decomposition"
+        if parser.has_section(section):
+            lang = parser.get(section, "language", fallback="EN")
+            self.language = Language[lang.upper()]
+            self.wiktionary_path = parser.get(section, "wiktionary_path", fallback="")
+            self.primes_dir = parser.get(
+                section, "primes_dir", fallback=str(_CONFIG_DIR / "primes")
+            )
+            raw_stop = parser.get(section, "stop_words", fallback="")
+            self._stop_words = [w.strip() for w in raw_stop.split(",") if w.strip()]
+
+    def primes_words(self) -> List[str]:
+        path = Path(self.primes_dir) / "primes.txt"
+        if not path.exists():
+            return []
+        return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+
+    def stop_words(self) -> List[str]:
+        return self._stop_words
+
+    def filter_primes(self, words: List[str]) -> List[str]:
+        primes = set(self.primes_words())
+        return [w for w in words if w not in primes]

--- a/semantic_decomposition/word_type.py
+++ b/semantic_decomposition/word_type.py
@@ -1,0 +1,62 @@
+from enum import Enum
+
+
+class WordType(Enum):
+    JJ = "JJ"
+    NN = "NN"
+    NNP = "NNP"
+    NNPS = "NNPS"
+    NNS = "NNS"
+    RB = "RB"
+    RP = "RP"
+    IN = "IN"
+    VB = "VB"
+    VBD = "VBD"
+    VBN = "VBN"
+    VBP = "VBP"
+    TO = "TO"
+    VBG = "VBG"
+    CC = "CC"
+    DT = "DT"
+    CD = "CD"
+    PRP = "PRP"
+    PDT = "PDT"
+    POS = "POS"
+    PRPS = "PRP$"
+    SYM = "SYM"
+    WP = "WP"
+    WPS = "WP$"
+    UH = "UH"
+    FW = "FW"
+    WRB = "WRB"
+    WDT = "WDT"
+    VBZ = "VBZ"
+    MD = "MD"
+    JJR = "JJR"
+    JJS = "JJS"
+    RBR = "RBR"
+    RBS = "RBS"
+    LS = "LS"
+    EX = "EX"
+    UNKNOWN = "UNKNOWN"
+
+    def type(self) -> str:
+        noun_tags = {
+            WordType.NN, WordType.NNS, WordType.NNP, WordType.NNPS,
+        }
+        verb_tags = {
+            WordType.VB, WordType.VBD, WordType.VBG, WordType.VBN,
+            WordType.VBP, WordType.VBZ, WordType.MD,
+        }
+        adj_tags = {WordType.JJ, WordType.JJR, WordType.JJS}
+        adv_tags = {WordType.RB, WordType.RBR, WordType.RBS, WordType.WRB}
+
+        if self in noun_tags:
+            return "noun"
+        if self in verb_tags:
+            return "verb"
+        if self in adj_tags:
+            return "adjective"
+        if self in adv_tags:
+            return "adverb"
+        return "other"


### PR DESCRIPTION
## Summary

Adds a complete Python translation of the SemanticDecomposition project as the `semantic_decomposition/` package (commit `ed615dd`). 74 files, ~2 200 lines of Python replacing the 8-module Maven project.

## What changed

### Translation decisions

| Java concept | Python equivalent |
|---|---|
| Interface / abstract class | `abc.ABC` + `@abstractmethod` |
| `default` interface method | Concrete method in abstract class |
| `HashMap` / `HashSet` / `Hashtable` | `dict` / `set` / `defaultdict` |
| Getters / setters | `@property` |
| Circular type references | `TYPE_CHECKING` guard + string annotations |
| JGraphT `Graph` / `DefaultListenableGraph` | Custom `SemanticNet` (dict-backed adjacency) |
| Guava `LoadingCache` | `dict`-based `ConceptCache` (pickle persistence) |
| Guava `BiMap` | Two mirrored dicts in `DoubleMarkerPassing` |
| StanfordCoreNLP | Optional spaCy pipeline in `BaseDictionary` |
| `ExecutorService` thread pool | `concurrent.futures.ThreadPoolExecutor` |
| Java `enum` | `enum.Enum` |
| Singleton (`getInstance()`) | Class-level `_instance` pattern |

### Package structure

| Package | Key classes |
|---|---|
| `semantic_decomposition` | `Concept`, `Definition`, `WordType`, `Decomposition`, `DecompositionConfig`, `IConcept` |
| `exceptions` | `DictionaryDoesNotContainConceptException` |
| `settings` | `Config` (singleton, reads `~/.decomposition/decomposition.cfg`), `Language` enum |
| `persistence` | `ConceptCache` (singleton, pickle-backed) |
| `dictionaries` | `Dictionary` ABC, `BaseDictionary` (spaCy lemmatisation) |
| `entities.markers` | `DoubleMarker`, `DoubleMarkerWithOrigin`, `TypedMarker` |
| `entities.links` | `WeightedLink` + 6 typed subclasses (synonym, antonym, definition, hypernym, hyponym, arbitrary) |
| `entities.nodes` | `DoubleNode`, `DoubleNodeWithMultipleThresholds`, `TypedNode` |
| `entities.relations` | `Relation`, `Role`, `Synonym` |
| `entities.spreading_activation` | `MarkerPassingConfig`, `TypedMarkerPassingConfig` |
| `graph` | `SemanticNet`, `GraphUtil` |
| `graph.edges` | `EdgeType` enum, `WeightedEdge` |
| `graph.spreading_activation` | `CountTerminationCondition`, `DoubleSpreadingActivation` |
| `graph.spreading_activation.marker_passing` | `DoubleMarkerPassing`, `TypedMarkerPassing`, `MarkerPassingSemanticDistanceMeasure` |
| `distance` | `DataExample`, `SimilarityPair`, `SemanticDistanceMeasureInterface` |
| `marker_passing` | Full `SpreadingAlgorithm` base library (self-contained, mirrors `MarkerPassingAlgorithm` repo) |

## Test plan

- [ ] `python3 -c "from semantic_decomposition import Concept, Decomposition"` — no import errors
- [ ] `python3 -c "from semantic_decomposition.graph.spreading_activation.marker_passing import MarkerPassingSemanticDistanceMeasure"` — no import errors
- [ ] Implement a concrete `Dictionary` backend, call `Decomposition.init([...])`, decompose two concepts, run `MarkerPassingSemanticDistanceMeasure().compare_concepts(c1, c2)` and verify a float is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)